### PR TITLE
Render particles at proper location if canvas scrolled out

### DIFF
--- a/dist/activate-power-mode.js
+++ b/dist/activate-power-mode.js
@@ -160,6 +160,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    rendering = true;
 	    context.clearRect(0, 0, canvas.width, canvas.height);
 	    var rendered = false;
+	    var rect = canvas.getBoundingClientRect();
 	    for (var i = 0; i < particles.length; ++i) {
 	        var particle = particles[i];
 	        if (particle.alpha <= 0.1) continue;
@@ -170,8 +171,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        context.globalAlpha = particle.alpha;
 	        context.fillStyle = particle.color;
 	        context.fillRect(
-	            Math.round(particle.x - 1.5),
-	            Math.round(particle.y - 1.5),
+	            Math.round(particle.x - 1.5) - rect.left,
+	            Math.round(particle.y - 1.5) - rect.top,
 	            3, 3
 	        );
 	        rendered = true;

--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,7 @@ function loop() {
     rendering = true;
     context.clearRect(0, 0, canvas.width, canvas.height);
     var rendered = false;
+    var rect = canvas.getBoundingClientRect();
     for (var i = 0; i < particles.length; ++i) {
         var particle = particles[i];
         if (particle.alpha <= 0.1) continue;
@@ -114,8 +115,8 @@ function loop() {
         context.globalAlpha = particle.alpha;
         context.fillStyle = particle.color;
         context.fillRect(
-            Math.round(particle.x - 1.5),
-            Math.round(particle.y - 1.5),
+            Math.round(particle.x - 1.5) - rect.left,
+            Math.round(particle.y - 1.5) - rect.top,
             3, 3
         );
         rendered = true;


### PR DESCRIPTION
Canvas scrolled out when popup keyboard on Safari on iOS.
In this case, Canvas top of client rect is negative value, particles does not render proper location.

This fix, consider canvas offset when rendering particles.